### PR TITLE
Fixed Reliable network event overflow

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -163,27 +163,31 @@ Citizen.CreateThread(function()
 
                         else -- job only
 
-                            TriggerServerEvent("vorp_stores:getPlayerJob")
+                            
 
 
                             local distance = Vdist2(coords.x, coords.y, coords.z, storeConfig.x, storeConfig.y,
                                 storeConfig.z, true)
 
                             if (distance <= storeConfig.distanceOpenStore) then
-                                if CheckJob(storeConfig.AllowedJobs, PlayerJob) then
-                                    if tonumber(storeConfig.JobGrade) <= tonumber(JobGrade) then
-                                        sleep = false
-                                        local label = CreateVarString(10, 'LITERAL_STRING', storeConfig.PromptName)
-
-                                        PromptSetActiveGroupThisFrame(PromptGroup, label)
-                                        if Citizen.InvokeNative(0xC92AC953F0A982AE, OpenStores) then
+                               
+                                sleep = false
+                                local label = CreateVarString(10, 'LITERAL_STRING', storeConfig.PromptName)
+                                PromptSetActiveGroupThisFrame(PromptGroup, label)
+                                if Citizen.InvokeNative(0xC92AC953F0A982AE, OpenStores) then
+                                    TriggerServerEvent("vorp_stores:getPlayerJob")
+                                    Citizen.Wait(100)
+                                    if CheckJob(storeConfig.AllowedJobs, PlayerJob) then
+                                        if tonumber(storeConfig.JobGrade) <= tonumber(JobGrade) then
                                             OpenCategory(storeId)
-
                                             DisplayRadar(false)
                                             TaskStandStill(player, -1)
                                         end
+                                    else
+                                        TriggerEvent("vorp:NotifyLeft", _U("wrongJobTitle"),_U("wrongJobMsg"), "menu_textures", "cross", 4000, 'COLOR_WHITE')
                                     end
                                 end
+                        
                             end
 
 
@@ -231,21 +235,24 @@ Citizen.CreateThread(function()
                             storeConfig.z, true)
 
                         if (distance <= storeConfig.distanceOpenStore) then
-                            if CheckJob(storeConfig.AllowedJobs, PlayerJob) then
-                                if tonumber(storeConfig.JobGrade) <= tonumber(JobGrade) then
-
-                                    sleep = false
-                                    local label = CreateVarString(10, 'LITERAL_STRING', storeConfig.PromptName)
-
-                                    PromptSetActiveGroupThisFrame(PromptGroup, label)
-                                    if Citizen.InvokeNative(0xC92AC953F0A982AE, OpenStores) then
+                            
+                            sleep = false
+                            local label = CreateVarString(10, 'LITERAL_STRING', storeConfig.PromptName)
+                            PromptSetActiveGroupThisFrame(PromptGroup, label)
+                            if Citizen.InvokeNative(0xC92AC953F0A982AE, OpenStores) then
+                                TriggerServerEvent("vorp_stores:getPlayerJob")
+                                Citizen.Wait(100)
+                                if CheckJob(storeConfig.AllowedJobs, PlayerJob) then
+                                    if tonumber(storeConfig.JobGrade) <= tonumber(JobGrade) then
                                         OpenCategory(storeId)
-
                                         DisplayRadar(false)
                                         TaskStandStill(player, -1)
                                     end
+                                else
+                                    TriggerEvent("vorp:NotifyLeft", _U("wrongJobTitle"),_U("wrongJobMsg"), "menu_textures", "cross", 4000, 'COLOR_WHITE')
                                 end
                             end
+                       
                         end
 
 

--- a/languages/de_lang.lua
+++ b/languages/de_lang.lua
@@ -28,5 +28,7 @@ Locales["de_lang"] = {
   cantcarry = " Du kannst diesen Gegenstand nicht tragen",
   closed = "~e~Geschlossen ~o~",
   am = ":00~q~am bis ~o~",
-  pm = ":00~q~pm"
+  pm = ":00~q~pm",
+  wrongJobTitle = "Kein Zugriff",
+  wrongJobMsg = "Du bist nicht dazu berechtigt hier einzukaufen"
 }

--- a/languages/en_lang.lua
+++ b/languages/en_lang.lua
@@ -28,5 +28,7 @@ Locales["en_lang"] = {
     cantcarry = " you cant carry this item",
     closed = "~e~CLOSED ~o~",
     am = ":00~q~am to ~o~",
-    pm = ":00~q~pm"
+    pm = ":00~q~pm",
+    wrongJobTitle = "No Access",
+    wrongJobMsg = "You have no permission to buy things here"
 }

--- a/languages/fr_lang.lua
+++ b/languages/fr_lang.lua
@@ -28,5 +28,7 @@ Locales["fr_lang"] = {
     cantcarry = " vous ne pouvez pas porter cet item",
     closed = "~e~FERMÉ ~o~",
     am = ":00~q~am à ~o~",
-    pm = ":00~q~pm"
+    pm = ":00~q~pm",
+    wrongJobTitle = "Pas d'accès",
+    wrongJobMsg = "Tu n'es pas autorisé(e) à faire des achats ici"
 }

--- a/languages/it_lang.lua
+++ b/languages/it_lang.lua
@@ -28,5 +28,7 @@ Locales["it_lang"] = {
     cantcarry = "Non puoi trasportare più niente",
     closed = "~e~CLOSED ~o~",
     am = ":00~q~am to ~o~",
-    pm = ":00~q~pm"
+    pm = ":00~q~pm",
+    wrongJobTitle = "Nessun accesso",
+    wrongJobMsg = "Non sei autorizzato ad acquistare qui"
 }


### PR DESCRIPTION
The permanent server request for job status causes reliable network event overflow errors.

My Solution:
Job status is only asked if the Player interacts with the store and notify him when he has no permission to access it.

Added:
-client update
-Updated all languages